### PR TITLE
Bugs in ProtocolService fixed

### DIFF
--- a/src/main/java/etf/iot/cloud/platform/services/dto/StartupFetchingMessage.java
+++ b/src/main/java/etf/iot/cloud/platform/services/dto/StartupFetchingMessage.java
@@ -1,0 +1,18 @@
+package etf.iot.cloud.platform.services.dto;
+
+import lombok.*;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class StartupFetchingMessage {
+
+    private String type;
+    private List<Protocol> protocols;
+
+}

--- a/src/main/java/etf/iot/cloud/platform/services/enums/DataAggregationMethod.java
+++ b/src/main/java/etf/iot/cloud/platform/services/enums/DataAggregationMethod.java
@@ -1,5 +1,5 @@
 package etf.iot.cloud.platform.services.enums;
 
 public enum DataAggregationMethod {
-    MIN, MAX, AVG, SUM
+    NONE, MIN, MAX, AVG, SUM
 }

--- a/src/main/java/etf/iot/cloud/platform/services/services/impl/ProtocolDataServiceImpl.java
+++ b/src/main/java/etf/iot/cloud/platform/services/services/impl/ProtocolDataServiceImpl.java
@@ -160,9 +160,6 @@ public class ProtocolDataServiceImpl implements ProtocolDataService {
     @Override
     public void sendDataToDevice(ProtocolInputSetData protocolInputData) {
         try {
-            System.out.println(protocolInputData.getDataId());
-            System.out.println("Type = " + protocolInputData.getType());
-            System.out.println("Action = " + protocolInputData.getAction());
             String jsonPayload = objectMapper.writeValueAsString(protocolInputData);
             mqttPublisher.publish(PROTOCOL_TOPIC, jsonPayload);
         } catch (JsonProcessingException | MqttException e) {
@@ -190,7 +187,6 @@ public class ProtocolDataServiceImpl implements ProtocolDataService {
             protocolValueInputData.setAction("get_current_values");
             String jsonPayload = objectMapper.writeValueAsString(protocolValueInputData);
             mqttPublisher.publish(PROTOCOL_TOPIC, jsonPayload);
-            System.out.println("Request sent!!!");
         } catch (JsonProcessingException | MqttException e) {
             System.out.println("Exception = " + e.getMessage());
         }


### PR DESCRIPTION
Change protocol assignment removal message to contain identifiers, not all protocol information, so less data is received in gateway.
Create StartupFetching message which doesn't have action because it is unnecessary.
Delete unnecessary print messages.
Aggregation method enum should have NONE for INPUT messages.
Correct sync protocols logic problem, so protocol data assigned attribute is set to true.